### PR TITLE
Keep order of options in the add-on Configuration tab

### DIFF
--- a/repositoryupdater/addon.py
+++ b/repositoryupdater/addon.py
@@ -334,7 +334,7 @@ class Addon:
                     separators=(",", ": "),
                 )
             else:
-                yaml.dump(config, outfile, default_flow_style=False)
+                yaml.dump(config, outfile, default_flow_style=False, sort_keys=False)
 
         click.echo(crayons.green("Done"))
 


### PR DESCRIPTION

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/